### PR TITLE
V2 refactor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,5 @@ RUN echo "<Location /server-status>\n"\
 >> /usr/local/apache2/conf/httpd.conf
 
 WORKDIR /usr/local/apache2/htdocs/
-RUN mkdir download
 RUN chown -R $PUID:$PGID /usr/local/apache2/htdocs
-ENV IMG false
 CMD ["/bin/bash","/init.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,25 +2,22 @@ version: "3"
 services:
   5etools-docker:
     container_name: 5etools-docker
-    image: jafner/5etools-docker:latest
+    image: jafner/5etools-docker
     volumes:
-      - ~/5etools-docker/htdocs:/usr/local/apache2/htdocs
+      - 5etools-docker:/usr/local/apache2/htdocs
     ports:
      - 8080:80/tcp
     environment:
-     - IMG=
-     # defaults to "false"
-     # expects "true" or "false"
-     - AUTOUPDATE= 
-     # defaults to "true"
-     # expects "true" or "false"
-     - DL_TYPE=
-     # defaults to "github"
-     # expects "get", "github", or "mega"
-     # where "get" refers to the old `get.5e.tools` structure,
-     # "github" refers to the root of a specific github repository,
-     # and "mega" refers to a mega.nz download link
-     - DL_LINK=
-     # defaults to https://github.com/5etools-mirror-1/5etools-mirror-1.github.io.git
-     # expects a URL with the correct content for the DL_TYPE
-     # if you're using the github type, make sure the url ends with .git
+     - SOURCE=GITHUB 
+       # Required unless OFFLINE_MODE=TRUE
+       # Expects one of "GITHUB", "GET5ETOOLS", or "GET5ETOOLS-NOIMG". Where:
+       # GITHUB pulls from https://github.com/5etools-mirror-1/5etools-mirror-1
+       # GET5ETOOLS pulls from https://get.5e.tools
+       # GET5ETOOLS-NOIMG pulls from https://get.5e.tools without image files.
+       # The get.5e.tools source has been down (redirecting to 5e.tools) during development.
+       # This method is not tested.
+     #- OFFLINE_MODE=TRUE
+       # Optional. Expects "TRUE" or "FALSE". 
+
+volumes:
+  5etools-docker:

--- a/init.sh
+++ b/init.sh
@@ -1,57 +1,63 @@
 #!/bin/bash
 # based (loosely) on: https://wiki.5e.tools/index.php/5eTools_Install_Guide
 
-cd /usr/local/apache2/htdocs
+# Ensure clean, non-root ownership of the htdocs directory.
+# Delete index.html if it's the stock apache file. Otherwise it impedes the git clone.
+chown -R $PUID:$PGID /usr/local/apache2/htdocs
+if grep -Fq '<html><body><h1>It works!</h1></body></html>' "/usr/local/apache2/htdocs/index.html"; then
+  rm /usr/local/apache2/htdocs/index.html
+fi
 
-# this variable can be passed into the environment via docker run or docker-compose
-# since this variable is required, I declare it explicitly here
-# expects "get", "github", or "mega"
-# where "get" refers to the old `get.5e.tools` structure,
-# "github" refers to the root of a specific github repository,
-# and "mega" refers to a mega.nz download link
-# defaults to "github"
-DL_TYPE=${DL_TYPE:-github}
-
-# this variable can be passed into the environment via docker run or docker-compose
-# since this variable is required, I declare it explicitly here
-# expects a URL with the correct content for the DL_TYPE
-# defaults to the temporary github mirror
-DL_LINK=${DL_LINK:-https://github.com/5etools-mirror-1/5etools-mirror-1.github.io.git}
-
-# this variable can be passed into the environment via docker run or docker-compose
-# since this variable is required, I declare it explicitly here
-# expects "true" or "false"
-# defaults to "true"
-AUTOUPDATE=${AUTOUPDATE:-true}
-
-# this variable can be passed into the environment via 
-# expects "true" or "false"
-# defaults to "false"
-IMG=${IMG:-false}
-
-
-if [ $AUTOUPDATE = false ]; then 
-  # if the user doesn't want to update from a source, 
-  # check for local version
-  # if local version is found, print version and start server
-  # if no local version is found, print error message and exit 1
-  echo "Auto update disabled. Checking for local version..."
+# If the user doesn't want to update from a source, 
+# check for local version.
+# If local version is found, print version and start server.
+# If no local version is found, print error message and exit.
+if [ "$OFFLINE_MODE" = "TRUE" ]; then 
+  echo "Offline mode is enabled. Will try to launch from local files. Checking for local version..."
   if [ -f /usr/local/apache2/htdocs/package.json ]; then
     VERSION=$(jq -r .version package.json) # Get version from package.json
     echo " === Starting version $VERSION"
+    httpd-foreground
   else
     echo " === No local version detected. Exiting."
     exit 1
   fi
-else
-  # if the user does want to update from a source,
-  # check if url provided via the $DL_LINK env variable is connectable
-  echo "Auto update enabled. Checking for remote version..."
-  echo " === Checking connection to $DL_LINK..."
-  SITE_STATUS=$(curl -s -o /dev/null -w "%{http_code}" $DL_LINK)
-  if [ $SITE_STATUS = 200 ] || [ $SITE_STATUS = 301 ]; then # if the source URL is reachable
-    if [ $DL_TYPE = "get" ]; then # the get.5e.tools structure
-      echo " === Using get structure to download from $DL_LINK"
+fi
+
+# The SOURCE variable must be set if OFFLINE_MODE is not TRUE
+if [ -z "${SOURCE}" ]; then
+  echo "SOURCE variable not set. Expects one of \"GITHUB\", \"GET5ETOOLS\", or \"GET5ETOOLS-NOIMG\". Exiting."
+  exit 1
+fi
+
+# Move to the working directory for working with files.
+cd /usr/local/apache2/htdocs
+
+echo " === Checking directory permissions for /usr/local/apache2/htdocs"
+ls -ld /usr/local/apache2/htdocs
+
+SOURCE=${SOURCE}
+case $SOURCE in 
+  "GITHUB")
+    DL_LINK=https://github.com/5etools-mirror-1/5etools-mirror-1.github.io.git
+    echo " === Using GitHub structure to update from $DL_LINK"
+      echo " === Warning: images will be downloaded automatically, which will take longer"
+      if [ ! -d "./.git" ]; then # if no git repository already exists
+        echo " === No existing git repository, creating one"
+        git config --global user.email "autodeploy@jafner.tools"
+        git config --global user.name "AutoDeploy"
+        git config --global pull.rebase false # Squelch nag message
+        git clone --depth=1 $DL_LINK .
+      fi
+      echo " === Pulling from GitHub... (This might take a while)"
+      git pull --depth=1 origin master #2> /dev/null
+      VERSION=$(jq -r .version package.json) # Get version from package.json
+      echo " === Starting version $VERSION"
+      httpd-foreground
+      ;;
+  "GET5ETOOLS*")
+    DL_LINK=https://get.5e.tools
+    echo " === Using get structure to download from $DL_LINK"
       echo " === WARNING: This part of the script has not yet been tested. Please open an issue on the github if you have trouble."
       # get remote version number
       # takes three steps of wizardry. I did not write this, but it works so I don't touch it.
@@ -66,7 +72,7 @@ else
         cd ./download/
         curl --progress-bar -k -O -J $DL_LINK/src/ -C -
         
-        if [ "$IMG" = "true" ]; then # download images
+        if [ "$SOURCE" != *"NOIMG"* ]; then # download images
           echo " === Downloading images... "
           curl --progress-bar -k -O -J $DL_LINK/img/ -C -
         fi
@@ -76,7 +82,7 @@ else
         echo " === Extracting site..."
         7z x ./download/$FILENAME -o./ -y
 
-        if [ "$IMG" = "true" ]; then # extract images
+        if [ "$SOURCE" != *"NOIMG"* ]; then # extract images
           echo " === Extracting images..."
           7z x ./download/$FILENAME_IMG -o./img -y
           mv ./img/tmp/5et/img/* ./img
@@ -99,73 +105,10 @@ else
       VERSION=$(jq -r .version package.json) # Get version from package.json
       echo " === Starting version $VERSION"
       httpd-foreground
-    elif [ $DL_TYPE = "github" ]; then # the github structure
-      echo " === Using GitHub structure to update from $DL_LINK"
-      echo " === Warning: images will be downloaded automatically, which will take longer"
-      if [ ! -d "./.git" ]; then # if no git repository already exists
-        git config --global user.email "autodeploy@jafner.tools"
-        git config --global user.name "AutoDeploy"
-        git init > /dev/null 2>&1
-        git add . > /dev/null
-        git commit -m "Init" > /dev/null
-        git remote add upstream $DL_LINK
-      fi
-      echo " === Pulling from GitHub... (This might take a while)"
-      git pull --depth=1 upstream master 2> /dev/null
-      VERSION=$(jq -r .version package.json) # Get version from package.json
-      echo " === Starting version $VERSION"
-      httpd-foreground
-    elif [ $DL_TYPE = "mega" ]; then # the mega structure
-      echo " === Using mega structure to download from $DL_LINK"
-      echo " === Warning: This method will overwrite the current local version because it cannot check the remote version"
-      echo " === Warning: This method ignores the IMG environment variable."
-      # downloading files
-      mkdir -p ./download
-      megadl --path ./download/ --no-progress --print-names $DL_LINK > filename # downloads the file to ./download/ and redirects the filename to a file called filename
-      FILENAME=$(cat filename) 
-      rm filename
+      ;;
+  *)
+    echo "SOURCE variable set incorrectly. Exiting..."
+    exit
+    ;;
 
-      # extracting files
-      echo " === Extracting site..."
-      7z x ./download/$FILENAME -o./ -y
-
-      # configuring the index.html and 5etools.html files
-      echo " === Configuring..." # honestly I don't know enough HTML/CSS/JS to tell exactly what this part of the script does :L
-      find . -name \*.html -exec sed -i 's/"width=device-width, initial-scale=1"/"width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"/' {} \;
-      sed -i 's/<head>/<head>\n<link rel="apple-touch-icon" href="icon\/icon-512.png">/' index.html
-      sed -i 's/navigator.serviceWorker.register("\/sw.js/navigator.serviceWorker.register("sw.js/' index.html
-      sed -i 's/navigator.serviceWorker.register("\/sw.js/navigator.serviceWorker.register("sw.js/' 5etools.html
-
-      # cleaning up downloads
-      echo " === Cleaning up downloads"
-      find ./download/ -type f ! -name "*.${VER}.zip" -exec rm {} + # delete the downloaded zip files
-
-      # starting the server
-      VERSION=$(jq -r .version package.json) # Get version from package.json
-      echo " === Starting version $VERSION"
-      httpd-foreground
-    else # if the DL_TYPE env var is not recognized
-      echo " === Could not determine download structure."
-      if [ -f /usr/local/apache2/htdocs/package.json ]; then
-        VERSION=$(jq -r .version package.json) # Get version from package.json
-        echo " === Falling back to local version: $VERSION"
-        httpd-foreground
-      else
-        echo " === No local version found! You must be able to access $DL_LINK to grab the 5eTools files."
-        echo " === Hint: Make sure you have the correct DL_TYPE environment variable set."
-        exit 1
-      fi
-    fi
-  else # if the download source is not accessible
-    echo " === Could not connect to $DL_LINK"
-    if [ -f /usr/local/apache2/htdocs/package.json ]; then
-      VERSION=$(jq -r .version package.json) # Get version from package.json
-      echo " === Falling back to local version: $VERSION"
-      httpd-foreground
-    else
-      echo " === No local version found! You must be able to access $DL_LINK to grab the 5eTools files."
-      echo " === Hint: Make sure you have the correct DL_TYPE environment variable set."
-      exit 1
-    fi
-  fi
-fi
+esac


### PR DESCRIPTION
Many changes here. 

- Switch from chained `if; then; else; fi` blocks to a `case` block.
- Reorganize error checking to fail faster.
- Drop support for Mega.
- Consolidate environment variables to `SOURCE` and `OFFLINE_MODE` (optional).
- Improve git handling to fix issue with pre-existing `index.html` file. 
- Enable seamless support for compose-, and docker-managed volumes, in addition to host volume mapping.

While I was able to test this extensively with the GITHUB source, get.5e.tools being down means I cannot test that source.  
Additionally, homebrew functionality is untested with this version.